### PR TITLE
Rename functions in the compiled module

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 Cassette = "7057c7e9-c182-5462-911a-8362d720325c"
+DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -1,6 +1,6 @@
 module StaticCompiler
 
-export irgen, write_object, fix_globals!, optimize!
+export irgen, write_object, fix_globals!, optimize!, @extern
 
 import Libdl
 
@@ -20,5 +20,6 @@ include("ccalls.jl")
 include("globals.jl")
 include("overdub.jl")
 include("irgen.jl")
+include("extern.jl")
 
 end # module

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -7,11 +7,12 @@ import Libdl
 using LLVM
 using LLVM.Interop
 using TypedCodeUtils
-import TypedCodeUtils: reflect, filter, lookthrough, canreflect,
+import TypedCodeUtils: reflect, lookthrough, canreflect,
                        DefaultConsumer, Reflection, Callsite,
                        identify_invoke, identify_call, identify_foreigncall,
                        process_invoke, process_call
 using MacroTools
+using DataStructures: MultiDict
 
 
 include("serialize.jl")

--- a/src/extern.jl
+++ b/src/extern.jl
@@ -1,0 +1,16 @@
+"""
+    @extern(fun, returntype, argtypes, args...)
+
+Creates a call to an external function meant to be included at link time. 
+Use the same conventions as `ccall`.
+    
+This transforms into the following `ccall`:
+
+    ccall("extern fun", llvmcall, returntype, argtypes, args...)
+"""
+macro extern(name, rettyp, argtyp, args...)
+    externfun = string("extern ", name isa AbstractString || name isa Symbol ? name : name.value)
+    Expr(:call, :ccall, externfun, esc(:llvmcall), esc(rettyp), 
+         Expr(:tuple, esc.(argtyp.args)...), esc.(args)...)
+end
+

--- a/src/globals.jl
+++ b/src/globals.jl
@@ -155,7 +155,7 @@ function fix_globals!(mod::LLVM.Module)
     d = find_ccalls(deser_fun, tt)
     fix_ccalls!(deser_mod, d)
     # rename deserialization function to "_deserialize_globals"
-    fun = first(filter(x -> LLVM.name(x) == "_deserialize_globals", functions(deser_mod)))[2]
+    fun = first(TypedCodeUtils.filter(x -> LLVM.name(x) == "_deserialize_globals", functions(deser_mod)))[2]
     # LLVM.name!(fun, "_deserialize_globals")
     linkage!(fun, LLVM.API.LLVMExternalLinkage)
     # link into the main module

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -138,7 +138,7 @@ function irgen(@nospecialize(func), @nospecialize(tt); optimize = true, overdub 
                     (Any, UInt, Bool, Bool, Base.CodegenParams),
                     linfo, world, #=wrapper=#false, #=optimize=#false, params)
         if ref == C_NULL
-            # error(jlctx[], "the Julia compiler could not generate LLVM IR")
+            #  error(jlctx[], "the Julia compiler could not generate LLVM IR")
         end
 
         llvmf = LLVM.Function(ref)

--- a/src/irgen.jl
+++ b/src/irgen.jl
@@ -216,7 +216,9 @@ function irgen(@nospecialize(func), @nospecialize(tt); optimize = true, overdub 
         basename = mi.def.name
         args = join(collect(mi.specTypes.parameters)[2:end], "_")
         if basename == :overdub  # special handling for Cassette
-            basename = mi.specTypes.parameters[3]
+            basename = string(mi.specTypes.parameters[3])
+            basename = replace(basename, r"^typeof\(" => "")
+            basename = replace(basename, r"\)$" => "")
             args = join(collect(mi.specTypes.parameters)[4:end], "_")
         end
         newname = join([basename, args, id], "_")

--- a/test/ccalls.jl
+++ b/test/ccalls.jl
@@ -32,3 +32,10 @@ end
     LLVM.verify(m)
     @test f() == @jlrun f()
 end
+
+@testset "extern" begin
+    f() = @extern(:time, Cvoid, (Ptr{Cvoid},), C_NULL)
+    m = irgen(f, Tuple{})
+    LLVM.verify(m)
+    @test "time" in [name(f) for f in LLVM.functions(m)]
+end


### PR DESCRIPTION
Functions are renamed to include argument types. Cassette overdubs are handled specially to  include the base function called. That helps with debugging, so not every function is `overdub_xxxxxxx`.

This pulls in more code from CUDAnative to support renaming. It also removes some duplicated methods in the compiled LLVM module.
