### PR TITLE
Add current package # for unregistered package

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,8 @@ jobs:
       - uses: julia-actions/setup-julia@latest
         with:
           version: ${{ matrix.julia-version }}
+      - name : Add current package # for unregistered package
+        run: julia -e 'using Pkg; Pkg.develop(PackageSpec(; path=pwd()));'
       - name: Install dependencies
         run: julia --project=docs -e 'using Pkg; Pkg.instantiate()'
       - name: Build and deploy

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,3 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"
+#StaticCompiler = "81625895-6c0f-48fc-b932-11a18313743c"


### PR DESCRIPTION
Patch for https://github.com/tshort/StaticCompiler.jl/pull/21
> The run here fails to add StaticCompiler.
> https://github.com/tshort/StaticCompiler.jl/runs/448105083?check_suite_focus=true#step:4:11
> 
> 1) we can register StaticCompiler and fix the error
> 2) I can add a line to add StaticCompiler based on the link.
> 
> I will 2 for now until you register. 

**We should revert these commits once StaticCompiler is registered**