### PR TITLE
Add `compile_executable`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
 authors = ["Tom Short"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
 authors = ["Tom Short"]
-version = "0.4.0"
+version = "0.3.0"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -137,9 +137,9 @@ instantiate(f::StaticCompiledFunction) = f
 
 """
 ```julia
-compile_executable(f, tt::Tuple, path::String, name::String=repr(f); filename::String=name, kwargs...)
+compile_executable(f, types::Tuple, path::String, name::String=repr(f); filename::String=name, kwargs...)
 ```
-Attempt to compile a standalone executable that runs function `f` with a type signature given by the tuple of types `tt`.
+Attempt to compile a standalone executable that runs function `f` with a type signature given by the tuple of `types`.
 
 ### Examples
 ```julia
@@ -379,8 +379,8 @@ function generate_executable(f, tt, path::String = tempname(), name = GPUCompile
         write(io, obj)
         flush(io)
 
-        # Pick a Clang
-        cc = Sys.isapple() ? `cc` : clang()
+        # Pick a compiler
+        cc = Sys.isapple() ? `cc` : `gcc`
         # Compile!
         run(`$cc -e $entry -o $exec_path $obj_path`)
     end

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -379,7 +379,7 @@ function generate_executable(f, tt, path::String = tempname(), name = GPUCompile
         flush(io)
 
         # Pick a compiler
-        cc = Sys.isapple() ? `cc` : `gcc`
+        cc = Sys.isapple() ? `cc` : clang()
         # Compile!
         if Sys.isapple()
             # Apple no longer uses _start, so we can just specify a custom entry

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -145,7 +145,8 @@ Attempt to compile a standalone executable that runs function `f` with a type si
 ```julia
 julia> using StaticCompiler
 
-julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
+julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates.
+           # Note, this `llvmcall` requires Julia 1.8+
            Base.llvmcall((\"""
            ; External declaration of the puts function
            declare i32 @puts(i8* nocapture) nounwind

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -198,8 +198,7 @@ function compile_executable(f, _tt=(), path::String="./", name=GPUCompiler.safe_
     tt == Tuple{} || tt == Tuple{Int, Ptr{Ptr{UInt8}}} || error("input type signature $_tt must be either () or (Int, Ptr{Ptr{UInt8}})")
 
     rt = only(native_code_typed(f, tt))[2]
-    # Warning instead of error because return values are probably going to be ignored anyways
-    isconcretetype(rt) || @warn "$f$_tt did not infer to a concrete type. Got $rt."
+    isconcretetype(rt) || error("$f$_tt did not infer to a concrete type. Got $rt")
 
     # Would be nice to use a compiler pass or something to check if there are any heap allocations or references to globals
     # Keep an eye on https://github.com/JuliaLang/julia/pull/43747 for this

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -139,7 +139,7 @@ instantiate(f::StaticCompiledFunction) = f
 ```julia
 compile_executable(f, tt::Tuple, path::String, name::String=repr(f); filename::String=name, kwargs...)
 ```
-Attempt to compile a standalone executable that runs `f`.
+Attempt to compile a standalone executable that runs function `f` with a type signature given by the tuple of types `tt`.
 
 ### Examples
 ```julia

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,7 +203,7 @@ end
             """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
         end
 
-        @inline Base.@ccallable function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+        @inline Base.@ccallable Int function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
             for i=1:argc
                 # Get pointer
                 p = unsafe_load(argv, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -189,7 +189,23 @@ end
 end
 
 @testset "Standalone Executables" begin
-    if VERSION>v"1.7" # The llvmcall here only works on 1.8+
+    # Minimal test with no `llvmcall`
+    @inline function foo()
+        v = 0.0
+        n = 1000
+        for i=1:n
+            v += sqrt(n)
+        end
+        return 0
+    end
+
+    filepath = compile_executable(foo, (), tempdir())
+
+    r = run(`$filepath`);
+    @test isa(r, Base.Process)
+    @test r.exitcode == 0
+
+    if VERSION>v"1.8.0-DEV" # The llvmcall here only works on 1.8+
         @inline function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
             Base.llvmcall(("""
             ; External declaration of the puts function
@@ -212,7 +228,7 @@ end
             end
             return 0
         end
-        
+
         filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), tempdir())
 
         r = run(`$filepath Hello, world!`);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,16 +33,16 @@ fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2) # This needs to be defined globall
     # Trick to work around #40990
     _fib2(_fib2, n) = n <= 1 ? n : _fib2(_fib2, n-1) + _fib2(_fib2, n-2)
     fib2(n) = _fib2(_fib2, n)
-    
+
     _, path = compile(fib2, (Int,))
     @test remote_load_call(path, 20) == fib(20)
-    #@test compile(fib2, (Int,))[1](20) == fib(20)    
+    #@test compile(fib2, (Int,))[1](20) == fib(20)
 end
 
 # Call binaries for testing
 # @testset "Generate binary" begin
 #     fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
-#     libname = tempname() 
+#     libname = tempname()
 #     generate_shlib(fib, (Int,), libname)
 #     ptr = Libdl.dlopen(libname * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
 #     fptr = Libdl.dlsym(ptr, "julia_fib")
@@ -62,7 +62,7 @@ end
     end
     _, path = compile(sum_first_N_int, (Int,))
     @test remote_load_call(path, 10) == 55
-    
+
     function sum_first_N_float64(N)
         s = Float64(0)
         for a in 1:N
@@ -116,10 +116,10 @@ end
 
 # Julia wants to treat Tuple (and other things like it) as plain bits, but LLVM wants to treat it as something with a pointer.
 # We need to be careful to not send, nor receive an unwrapped Tuple to a compiled function.
-# The interface made in `compile` should handle this fine. 
+# The interface made in `compile` should handle this fine.
 @testset "Send and receive Tuple" begin
     foo(u::Tuple) = 2 .* reverse(u) .- 1
-    
+
     _, path = compile(foo, (NTuple{3, Int},))
     @test remote_load_call(path, (1, 2, 3)) == (5, 3, 1)
 end
@@ -172,7 +172,7 @@ end
 end
 
 # This is a trick to get stack allocated arrays inside a function body (so long as they don't escape).
-# This lets us have intermediate, mutable stack allocated arrays inside our 
+# This lets us have intermediate, mutable stack allocated arrays inside our
 @testset "Alloca" begin
     function f(N)
         # this can hold at most 100 Int values, if you use it for more, you'll segfault
@@ -186,7 +186,36 @@ end
     end
     _, path = compile(f, (Int,))
     @test remote_load_call(path, 20) == 20
-end 
+end
 
+@testset "Standalone Executables" begin
+    function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
+        Base.llvmcall(("""
+        ; External declaration of the puts function
+        declare i32 @puts(i8* nocapture) nounwind
 
+        define i32 @main(i8*) {
+        entry:
+           %call = call i32 (i8*) @puts(i8* %0)
+           ret i32 0
+        }
+        """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
+    end
+
+    function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+        for i=1:argc
+            # Get pointer
+            p = unsafe_load(argv, i)
+            # Print string at pointer location (which fortunately already exists isn't tracked by the GC)
+            puts(p)
+        end
+        return 0
+    end
+
+    filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), tempdir())
+
+    r = run(`$filepath Hello, world!`);
+    @test isa(r, Base.Process)
+    @test r.exitcode == 0
+end
 # data structures, dictionaries, tuples, named tuples

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
 
 @testset "Standalone Executables" begin
     if VERSION>v"1.7" # The llvmcall here only works on 1.8+
-        function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
+        Base.@ccallable function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
             Base.llvmcall(("""
             ; External declaration of the puts function
             declare i32 @puts(i8* nocapture) nounwind
@@ -203,7 +203,7 @@ end
             """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
         end
 
-        function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+        Base.@ccallable function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
             for i=1:argc
                 # Get pointer
                 p = unsafe_load(argv, i)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -205,7 +205,7 @@ end
     @test isa(r, Base.Process)
     @test r.exitcode == 0
 
-    if VERSION>v"1.8.0-DEV" # The llvmcall here only works on 1.8+
+    @static if VERSION>v"1.8.0-DEV" # The llvmcall here only works on 1.8+
         @inline function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
             Base.llvmcall(("""
             ; External declaration of the puts function

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,7 +203,7 @@ end
             """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
         end
 
-        @inline Base.@ccallable Int function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+        @inline function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
             for i=1:argc
                 # Get pointer
                 p = unsafe_load(argv, i)
@@ -212,7 +212,7 @@ end
             end
             return 0
         end
-
+        
         filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), tempdir())
 
         r = run(`$filepath Hello, world!`);

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -190,7 +190,7 @@ end
 
 @testset "Standalone Executables" begin
     if VERSION>v"1.7" # The llvmcall here only works on 1.8+
-        Base.@ccallable function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
+        @inline function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates
             Base.llvmcall(("""
             ; External declaration of the puts function
             declare i32 @puts(i8* nocapture) nounwind
@@ -203,7 +203,7 @@ end
             """, "main"), Int32, Tuple{Ptr{UInt8}}, s)
         end
 
-        Base.@ccallable function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
+        @inline Base.@ccallable function print_args(argc::Int, argv::Ptr{Ptr{UInt8}})
             for i=1:argc
                 # Get pointer
                 p = unsafe_load(argv, i)


### PR DESCRIPTION
This PR adds a new exported function `compile_executable`, which compiles a standalone native executable (in comparison to the existing `compile`, which compiles a `.dylib`/`.so` shared library.

The restrictions on what can be done are largely the same as those of `compile`, except that here the function signature can only be either nothing (i.e.`foo()`) or those of a normal C program's `main` function (i.e. `foo(argc::Int, argv::Ptr{Ptr{UInt8}}`)