### PR TITLE
Improve sanity take 2

### DIFF
--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -223,7 +223,7 @@ function generate_shlib(f, tt, path::String = tempname(), name = GPUCompiler.saf
     mod, meta = GPUCompiler.codegen(:llvm, job; strip=strip_llvm, only_entry=false, validate=false)
 
     table = relocation_table!(mod)
-    
+    LLVM.verify(mod)
     obj, _ = GPUCompiler.emit_asm(job, mod; strip=strip_asm, validate=false, format=LLVM.API.LLVMObjectFile)
     
     open(obj_path, "w") do io

--- a/src/code_loading.jl
+++ b/src/code_loading.jl
@@ -15,6 +15,14 @@ struct LazyStaticCompiledFunction{rt, tt}
     reloc::IdDict{Any,String}
 end
 
+"""
+    unsafe_pointer_from_objref(x)
+Sometimes Julia embeds immutables like `Base.string` into code, and julia
+will error if you call `pointer_from_objref(string)`, claiming that it
+doesn't have a pointer even though that's a lie.
+"""
+unsafe_pointer_from_objref(x) = ccall(:jl_value_ptr, Ptr{Cvoid}, (Any,), x)
+
 function instantiate(p::LazyStaticCompiledFunction{rt, tt}) where {rt, tt}
     # LLVM.load_library_permantly(dirname(Libdl.dlpath(Libdl.dlopen("libjulia"))))
     lljit = LLVM.LLJIT(;tm=LLVM.JITTargetMachine())
@@ -25,14 +33,7 @@ function instantiate(p::LazyStaticCompiledFunction{rt, tt}) where {rt, tt}
     
     # Set all the uninitialized global variables to point to julia values from the relocation table
     for (val, name) ∈ p.reloc
-        if !ismutable(val)
-            # Sometimes Julia embeds functions like `Base.string` into code, and this doesn't have a pointer
-            # so we need to give it one manually, and put the ref in the dict to make sure it doesn't expire.
-            delete!(p.reloc, val)
-            val = Ref(val)
-            p.reloc[val] = name
-        end
-        address = LLVM.API.LLVMOrcJITTargetAddress(reinterpret(UInt, pointer_from_objref(val)))
+        address = LLVM.API.LLVMOrcJITTargetAddress(reinterpret(UInt, unsafe_pointer_from_objref(val)))
 
         symbol = LLVM.API.LLVMJITEvaluatedSymbol(address, flags)
         gv = LLVM.API.LLVMJITCSymbolMapPair(LLVM.mangle(lljit, name), symbol)

--- a/src/pointer_patching.jl
+++ b/src/pointer_patching.jl
@@ -1,6 +1,5 @@
 function relocation_table!(mod)
     i64 = LLVM.IntType(64; ctx=LLVM.context(mod))
-    jl_t = LLVM.PointerType(LLVM.StructType(LLVM.LLVMType[]; ctx=LLVM.context(mod)))
     d = IdDict{Any, Tuple{String, LLVM.GlobalVariable}}()
     
     for func ∈ LLVM.functions(mod), bb ∈ LLVM.blocks(func), inst ∈ LLVM.instructions(bb)
@@ -137,7 +136,7 @@ function get_pointers!(d, mod, inst)
                         LLVM.API.LLVMSetOperand(inst, i-1, gv)
                     else
                         gv_name = GPUCompiler.safe_name(String(gensym(repr(Core.Typeof(val)))))
-                        gv = LLVM.GlobalVariable(mod, jl_t, gv_name)
+                        gv = LLVM.GlobalVariable(mod, llvmeltype(arg), gv_name)
                         LLVM.extinit!(gv, true)
                         LLVM.API.LLVMSetOperand(inst, i-1, gv)
 
@@ -150,6 +149,8 @@ function get_pointers!(d, mod, inst)
         end
     end
 end
+
+llvmeltype(x::LLVM.Value) = LLVM.LLVMType(LLVM.API.LLVMGetElementType(LLVM.llvmtype(x)))
 
 function absolute_symbols(symbols)
     ref = LLVM.API.LLVMOrcAbsoluteSymbols(symbols, length(symbols))
@@ -168,7 +169,12 @@ function pointer_patching_diff(mod::LLVM.Module, path1=tempname(), path2=tempnam
     s2 = string(mod)
     write(path2, s2)
 
-    run(`diff $p1 $p2`)
+    try
+        # this always ends in an error for me for some reason
+        run(`diff $path1 $path2`)
+    catch e;
+        nothing
+    end
 end
 
 


### PR DESCRIPTION
verify the IR, and don't just tell LLVM that every global variable is a `{}*`.