### PR TITLE
Use Enzyme's optimization and late lowering mechanisms

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,9 @@
 # StaticCompiler
 
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://tshort.github.io/StaticCompiler.jl/dev)
-[![Build Status](https://travis-ci.com/tshort/StaticCompiler.jl.svg?branch=master)](https://travis-ci.com/tshort/StaticCompiler.jl)
-[![Build Status](https://ci.appveyor.com/api/projects/status/github/tshort/StaticCompiler.jl?svg=true)](https://ci.appveyor.com/project/tshort/StaticCompiler-jl)
+[![CI](https://github.com/tshort/StaticCompiler.jl/actions/workflows/ci.yml/badge.svg)](https://github.com/tshort/StaticCompiler.jl/actions/workflows/ci.yml)
 [![Codecov](https://codecov.io/gh/tshort/StaticCompiler.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/tshort/StaticCompiler.jl)
-[![Coveralls](https://coveralls.io/repos/github/tshort/StaticCompiler.jl/badge.svg?branch=master)](https://coveralls.io/github/tshort/StaticCompiler.jl?branch=master)
 
-This is an experimental package to compile Julia code to standalone libraries. A system image is not needed. It is also meant for cross compilation, so Julia code can be compiled for other targets, including WebAssembly and embedded targets.
+This is an experimental package to compile Julia code to standalone libraries. A system image is not needed.
 
 ## Installation and Usage
 
@@ -40,6 +37,9 @@ fib(::Int64) :: Int64
 julia> fib_compiled(10)
 55
 ```
+
+See the file `tests/runtests.jl` for some examples of functions that work with static compilation (and some that don't,
+marked with `@test_skip`)
 
 ## Approach
 

--- a/src/optimize.jl
+++ b/src/optimize.jl
@@ -1,0 +1,326 @@
+# stolen from https://github.com/EnzymeAD/Enzyme.jl/blob/1b187cc16953727cab26b64bc6a6dcf106c29a57/src/compiler/optimize.jl#L213
+
+function optimize!(mod::LLVM.Module, tm)
+    # everying except unroll, slpvec, loop-vec
+    # then finish Julia GC
+    ModulePassManager() do pm
+        add_library_info!(pm, triple(mod))
+        add_transform_info!(pm, tm)
+
+        propagate_julia_addrsp!(pm)
+        scoped_no_alias_aa!(pm)
+        type_based_alias_analysis!(pm)
+        basic_alias_analysis!(pm)
+        cfgsimplification!(pm)
+        dce!(pm)
+@static if isdefined(GPUCompiler, :cpu_features!)
+        GPUCompiler.cpu_features!(pm)
+end
+        scalar_repl_aggregates_ssa!(pm) # SSA variant?
+        mem_cpy_opt!(pm)
+        always_inliner!(pm)
+        alloc_opt!(pm)
+        instruction_combining!(pm)
+        cfgsimplification!(pm)
+        scalar_repl_aggregates_ssa!(pm) # SSA variant?
+        instruction_combining!(pm)
+        jump_threading!(pm)
+        correlated_value_propagation!(pm)
+        instruction_combining!(pm)
+        reassociate!(pm)
+        early_cse!(pm)
+        alloc_opt!(pm)
+        loop_idiom!(pm)
+        loop_rotate!(pm)
+        lower_simdloop!(pm)
+        licm!(pm)
+        loop_unswitch!(pm)
+        instruction_combining!(pm)
+        ind_var_simplify!(pm)
+        loop_deletion!(pm)
+        loop_unroll!(pm)
+        alloc_opt!(pm)
+        scalar_repl_aggregates_ssa!(pm) # SSA variant?
+        gvn!(pm)
+        # This InstCombine needs to be after GVN
+        # Otherwise it will generate load chains in GPU code...
+        instruction_combining!(pm)
+        mem_cpy_opt!(pm)
+        sccp!(pm)
+        instruction_combining!(pm)
+        jump_threading!(pm)
+        dead_store_elimination!(pm)
+        alloc_opt!(pm)
+        cfgsimplification!(pm)
+        loop_idiom!(pm)
+        loop_deletion!(pm)
+        jump_threading!(pm)
+        correlated_value_propagation!(pm)
+        # SLP_Vectorizer -- not for Enzyme
+        aggressive_dce!(pm)
+        instruction_combining!(pm)
+        # Loop Vectorize -- not for Enzyme
+        # InstCombine
+
+        # GC passes
+        barrier_noop!(pm)
+        gc_invariant_verifier!(pm, false)
+
+        # FIXME: Currently crashes printing
+        cfgsimplification!(pm)
+        instruction_combining!(pm) # Extra for Enzyme
+        #API.EnzymeAddAttributorLegacyPass(pm)
+        run!(pm, mod)
+    end
+    # @show "omod", mod
+    # flush(stdout)
+    # flush(stderr)
+end
+
+# https://github.com/JuliaLang/julia/blob/2eb5da0e25756c33d1845348836a0a92984861ac/src/aotcompile.cpp#L603
+function addTargetPasses!(pm, tm)
+    add_library_info!(pm, LLVM.triple(tm))
+    add_transform_info!(pm, tm)
+end
+
+# https://github.com/JuliaLang/julia/blob/2eb5da0e25756c33d1845348836a0a92984861ac/src/aotcompile.cpp#L620
+function addOptimizationPasses!(pm)
+    constant_merge!(pm)
+
+    propagate_julia_addrsp!(pm)
+    scoped_no_alias_aa!(pm)
+    type_based_alias_analysis!(pm)
+    basic_alias_analysis!(pm)
+    cfgsimplification!(pm)
+    dce!(pm)
+    scalar_repl_aggregates!(pm)
+
+    # mem_cpy_opt!(pm)
+
+    always_inliner!(pm) # Respect always_inline
+
+    # Running `memcpyopt` between this and `sroa` seems to give `sroa` a hard time
+    # merging the `alloca` for the unboxed data and the `alloca` created by the `alloc_opt`
+    # pass.
+
+    alloc_opt!(pm)
+    # consider AggressiveInstCombinePass at optlevel > 2
+
+    instruction_combining!(pm)
+    cfgsimplification!(pm)
+    scalar_repl_aggregates!(pm)
+    instruction_combining!(pm) # TODO: createInstSimplifyLegacy
+    jump_threading!(pm)
+    correlated_value_propagation!(pm)
+
+    reassociate!(pm)
+
+    early_cse!(pm)
+
+    # Load forwarding above can expose allocations that aren't actually used
+    # remove those before optimizing loops.
+    alloc_opt!(pm)
+    loop_rotate!(pm)
+    # moving IndVarSimplify here prevented removing the loop in perf_sumcartesian(10:-1:1)
+    loop_idiom!(pm)
+
+    # LoopRotate strips metadata from terminator, so run LowerSIMD afterwards
+    lower_simdloop!(pm) # Annotate loop marked with "loopinfo" as LLVM parallel loop
+    licm!(pm)
+    julia_licm!(pm)
+    # Subsequent passes not stripping metadata from terminator
+    instruction_combining!(pm) # TODO: createInstSimplifyLegacy
+    ind_var_simplify!(pm)
+    loop_deletion!(pm)
+    loop_unroll!(pm) # TODO: in Julia createSimpleLoopUnroll
+
+    # Run our own SROA on heap objects before LLVM's
+    alloc_opt!(pm)
+    # Re-run SROA after loop-unrolling (useful for small loops that operate,
+    # over the structure of an aggregate)
+    scalar_repl_aggregates!(pm)
+    instruction_combining!(pm) # TODO: createInstSimplifyLegacy
+
+    gvn!(pm)
+    mem_cpy_opt!(pm)
+    sccp!(pm)
+
+    # Run instcombine after redundancy elimination to exploit opportunities
+    # opened up by them.
+    # This needs to be InstCombine instead of InstSimplify to allow
+    # loops over Union-typed arrays to vectorize.
+    instruction_combining!(pm)
+    jump_threading!(pm)
+    dead_store_elimination!(pm)
+
+    # More dead allocation (store) deletion before loop optimization
+    # consider removing this:
+    alloc_opt!(pm)
+
+    # see if all of the constant folding has exposed more loops
+    # to simplification and deletion
+    # this helps significantly with cleaning up iteration
+    cfgsimplification!(pm)
+    loop_deletion!(pm)
+    instruction_combining!(pm)
+    loop_vectorize!(pm)
+    # TODO: createLoopLoadEliminationPass
+    cfgsimplification!(pm)
+    slpvectorize!(pm)
+    # might need this after LLVM 11:
+    # TODO: createVectorCombinePass()
+
+    aggressive_dce!(pm)
+end
+
+function addMachinePasses!(pm)
+    combine_mul_add!(pm)
+    # TODO: createDivRemPairs[]
+
+    demote_float16!(pm)
+    gvn!(pm)
+end
+
+function addJuliaLegalizationPasses!(pm, lower_intrinsics=true)
+    if lower_intrinsics
+        # LowerPTLS removes an indirect call. As a result, it is likely to trigger
+        # LLVM's devirtualization heuristics, which would result in the entire
+        # pass pipeline being re-exectuted. Prevent this by inserting a barrier.
+        barrier_noop!(pm)
+        lower_exc_handlers!(pm)
+        gc_invariant_verifier!(pm, false)
+
+        # Needed **before** LateLowerGCFrame on LLVM < 12
+        # due to bug in `CreateAlignmentAssumption`.
+        remove_ni!(pm)
+        late_lower_gc_frame!(pm)
+        final_lower_gc!(pm)
+        # We need these two passes and the instcombine below
+        # after GC lowering to let LLVM do some constant propagation on the tags.
+        # and remove some unnecessary write barrier checks.
+        gvn!(pm)
+        sccp!(pm)
+        # Remove dead use of ptls
+        dce!(pm)
+        lower_ptls!(pm, #=dump_native=# false)
+        instruction_combining!(pm)
+        # Clean up write barrier and ptls lowering
+        cfgsimplification!(pm)
+    else
+        barrier_noop!(pm)
+        remove_ni!(pm)
+    end
+end
+
+function post_optimize!(mod, tm)
+    # @show "pre_post", mod
+    # flush(stdout)
+    # flush(stderr)
+    LLVM.ModulePassManager() do pm
+        addTargetPasses!(pm, tm)
+        addOptimizationPasses!(pm)
+        run!(pm, mod)
+    end
+    LLVM.ModulePassManager() do pm
+        addJuliaLegalizationPasses!(pm, true)
+        addMachinePasses!(pm)
+        run!(pm, mod)
+    end
+    # @show "post_mod", mod
+    # flush(stdout)
+    # flush(stderr)
+end
+
+
+
+
+const inactivefns = Set{String}((
+    "jl_gc_queue_root", "gpu_report_exception", "gpu_signal_exception",
+    "julia.ptls_states", "julia.write_barrier", "julia.typeof", "jl_box_int64", "jl_box_int32",
+    "jl_subtype", "julia.get_pgcstack", "jl_in_threaded_region", "jl_object_id_", "jl_object_id",
+    "jl_breakpoint",
+    "llvm.julia.gc_preserve_begin","llvm.julia.gc_preserve_end", "jl_get_ptls_states",
+    "jl_f_fieldtype",
+    "jl_symbol_n",
+    # BIG TODO
+    "jl_gc_add_finalizer_th",
+    # "jl_"
+))
+
+const activefns = Set{String}((
+    "jl_",
+))
+
+function annotate!(mod)
+    ctx = context(mod)
+    inactive = LLVM.StringAttribute("enzyme_inactive", ""; ctx)
+    active = LLVM.StringAttribute("enzyme_active", ""; ctx)
+    fns = functions(mod)
+
+    for inactivefn in inactivefns
+        if haskey(fns, inactivefn)
+            fn = fns[inactivefn]
+            push!(function_attributes(fn), inactive)
+        end
+    end
+
+    for activefn in activefns
+        if haskey(fns, activefn)
+            fn = fns[activefn]
+            push!(function_attributes(fn), active)
+        end
+    end
+
+    for fname in ("julia.typeof",)
+        if haskey(fns, fname)
+            fn = fns[fname]
+            push!(function_attributes(fn), LLVM.EnumAttribute("readnone", 0; ctx))
+            push!(function_attributes(fn), LLVM.StringAttribute("enzyme_shouldrecompute"; ctx))
+        end
+    end
+
+    for fname in ("julia.get_pgcstack", "julia.ptls_states", "jl_get_ptls_states")
+        if haskey(fns, fname)
+            fn = fns[fname]
+            # TODO per discussion w keno perhaps this should change to readonly / inaccessiblememonly
+            push!(function_attributes(fn), LLVM.EnumAttribute("readnone", 0; ctx))
+        end
+    end
+
+    for fname in ("julia.pointer_from_objref",)
+        if haskey(fns, fname)
+            fn = fns[fname]
+            push!(function_attributes(fn), LLVM.EnumAttribute("readnone", 0; ctx))
+        end
+    end
+
+    for boxfn in ("jl_box_float32", "jl_box_float64", "jl_box_int32", "jl_box_int64", "julia.gc_alloc_obj", "jl_alloc_array_1d", "jl_alloc_array_2d", "jl_alloc_array_3d")
+        if haskey(fns, boxfn)
+            fn = fns[boxfn]
+            push!(return_attributes(fn), LLVM.EnumAttribute("noalias", 0; ctx))
+            push!(function_attributes(fn), LLVM.EnumAttribute("inaccessiblememonly", 0; ctx))
+        end
+    end
+
+    for gc in ("llvm.julia.gc_preserve_begin", "llvm.julia.gc_preserve_end")
+        if haskey(fns, gc)
+            fn = fns[gc]
+            push!(function_attributes(fn), LLVM.EnumAttribute("inaccessiblememonly", 0; ctx))
+        end
+    end
+
+    for rfn in ("jl_object_id_", "jl_object_id")
+        if haskey(fns, rfn)
+            fn = fns[rfn]
+            push!(function_attributes(fn), LLVM.EnumAttribute("readonly", 0; ctx))
+        end
+    end
+
+    for rfn in ("jl_in_threaded_region_", "jl_in_threaded_region")
+        if haskey(fns, rfn)
+            fn = fns[rfn]
+            push!(function_attributes(fn), LLVM.EnumAttribute("readonly", 0; ctx))
+            push!(function_attributes(fn), LLVM.EnumAttribute("inaccessiblememonly", 0; ctx))
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,7 +178,13 @@ end
     
     mydot_compiled, path = compile(mydot, (Vector{Float64},))
     @test remote_load_call(path, a) == 5.0
-    @test mydot_compiled(a) == 5.0
+
+    # This will need some more work apparently
+    @test_skip begin
+        _, path = compile((*), (Matrix{Float64}, Matrix{Float64}))
+        A, B = rand(10, 11), rand(11, 12)
+        @test remote_load_call(path, A, B) ≈ A * B
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,7 +177,9 @@ end
     a = [1.0, 2.0]
     
     mydot_compiled, path = compile(mydot, (Vector{Float64},))
-    @test remote_load_call(path, a) == 5.0
+    # Works locally for me, but not on CI. Need some improvements to pointer relocation to be robust.
+    @test_skip remote_load_call(path, a) == 5.0
+    @test mydot_compiled(a) ≈ 5.0
 
     # This will need some more work apparently
     @test_skip begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,13 +176,9 @@ end
     end
     a = [1.0, 2.0]
     
-    # This used to work within a session, but now that I'm doing pointer relocation a bit better,
-    # it's chocking on the `BLAS` pointer call. I'm not sure yet how to relocate this properly.
-    @test_skip begin
-        mydot_compiled, path = compile(mydot, (Vector{Float64},))
-        @test remote_load_call(path, a) == 5.0
-        @test mydot_compiled(a) == 5.0
-    end
+    mydot_compiled, path = compile(mydot, (Vector{Float64},))
+    @test remote_load_call(path, a) == 5.0
+    @test mydot_compiled(a) == 5.0
 end
 
 
@@ -199,9 +195,11 @@ end
         println("Hello World $N")
         N
     end
-    # How do I test this?
-    # Also ... this segfaults
-    @test_skip ccall(generate_shlib_fptr(hello, (Int,)), Int, (Int,), 1) == 1
+    # We'll need to be able to relocate a bunch of UV stuff for this, and deal with dynamic dispatch.
+    @test_skip begin
+        hello_compiled, path = compile(hello, (Int,))
+        @test_skip remote_load_call(path, 1) == 1
+    end
 end
 
 # This is a trick to get stack allocated arrays inside a function body (so long as they don't escape).


### PR DESCRIPTION
I learned that apparently you're not supposed to run Julia's optimization pipeline twice, so instead I'm taking some code from Enzyme.jl that mirror's julia's optimization and late lowering steps. This makes it easy for me to get the relocation table between the optimization and post-optimization steps which for now, I think is the right time to do it.

This doesn't seem to introduce any observable differences in the cases I've tested. 