### PR TITLE
Add `compile_dylib`

### DIFF
--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -149,7 +149,6 @@ function generate_shlib(f, tt, path::String = tempname(), name = GPUCompiler.saf
                         kwargs...)
     mkpath(path)
     obj_path = joinpath(path, "$filenamebase.o")
-    lib_path = joinpath(path, "$filenamebase.$(Libdl.dlext)")
     tm = GPUCompiler.llvm_machine(NativeCompilerTarget())
     job, kwargs = native_job(f, tt; name, kwargs...)
     #Get LLVM to generated a module of code for us. We don't want GPUCompiler's optimization passes.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -245,7 +245,7 @@ end
 
     #Compile dylib
     name = repr(fib)
-    filepath = compile_dylib(fib, (Int,), "./", name)
+    filepath = compile_shlib(fib, (Int,), "./", name)
     @test occursin("fib.$(Libdl.dlext)", filepath)
 
     # Open dylib

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -238,17 +238,15 @@ end
     @test C ≈ A*B
 end
 
-# Call binaries for testing
-# @testset "Standalone Dylibs" begin
-#     fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
-#     libname = tempname()
-#     generate_dylib(fib, (Int,), libname)
-#     ptr = Libdl.dlopen(libname * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
-#     fptr = Libdl.dlsym(ptr, "julia_fib")
-#     @assert fptr != C_NULL
-#     # This works on REPL
-#     @test_skip ccall(fptr, Int, (Int,), 10) == 55
-# end
+@testset "Standalone Dylibs" begin
+    fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
+    path, name = StaticCompiler.generate_dylib(fib, (Int,), "./")
+    ptr = Libdl.dlopen(name * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
+    fptr = Libdl.dlsym(ptr, "julia_$name")
+    @assert fptr != C_NULL
+    # This works on REPL
+    @test ccall(fptr, Int, (Int,), 10) == 55
+end
 
 
 @testset "Standalone Executables" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,18 +38,6 @@ fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2) # This needs to be defined globall
     #@test compile(fib2, (Int,))[1](20) == fib(20)
 end
 
-# Call binaries for testing
-# @testset "Generate binary" begin
-#     fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
-#     libname = tempname()
-#     generate_shlib(fib, (Int,), libname)
-#     ptr = Libdl.dlopen(libname * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
-#     fptr = Libdl.dlsym(ptr, "julia_fib")
-#     @assert fptr != C_NULL
-#     # This works on REPL
-#     @test_skip ccall(fptr, Int, (Int,), 10) == 55
-# end
-
 
 @testset "Loops" begin
     function sum_first_N_int(N)
@@ -154,7 +142,7 @@ end
             e
         end
     end
-    @test fetch(tsk) isa DomainError 
+    @test fetch(tsk) isa DomainError
 end
 
 # Julia wants to treat Tuple (and other things like it) as plain bits, but LLVM wants to treat it as something with a pointer.
@@ -175,7 +163,7 @@ end
         BLAS.dot(N, a, 1, a, 1)
     end
     a = [1.0, 2.0]
-    
+
     mydot_compiled, path = compile(mydot, (Vector{Float64},))
     # Works locally for me, but not on CI. Need some improvements to pointer relocation to be robust.
     @test_skip remote_load_call(path, a) == 5.0
@@ -250,6 +238,17 @@ end
     @test C ≈ A*B
 end
 
+# Call binaries for testing
+# @testset "Standalone Dylibs" begin
+#     fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
+#     libname = tempname()
+#     generate_dylib(fib, (Int,), libname)
+#     ptr = Libdl.dlopen(libname * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
+#     fptr = Libdl.dlsym(ptr, "julia_fib")
+#     @assert fptr != C_NULL
+#     # This works on REPL
+#     @test_skip ccall(fptr, Int, (Int,), 10) == 55
+# end
 
 
 @testset "Standalone Executables" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -239,12 +239,19 @@ end
 end
 
 @testset "Standalone Dylibs" begin
-    fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
-    path, name = StaticCompiler.generate_dylib(fib, (Int,), "./")
-    ptr = Libdl.dlopen(name * "." * Libdl.dlext, Libdl.RTLD_LOCAL)
+    # Test function
+    # (already defined)
+    # fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
+
+    #Compile dylib
+    name = repr(fib)
+    filepath = compile_dylib(fib, (Int,), "./", name)
+    @test occursin("fib.$(Libdl.dlext)", filepath)
+
+    # Open dylib
+    ptr = Libdl.dlopen(filepath, Libdl.RTLD_LOCAL)
     fptr = Libdl.dlsym(ptr, "julia_$name")
-    @assert fptr != C_NULL
-    # This works on REPL
+    @test fptr != C_NULL
     @test ccall(fptr, Int, (Int,), 10) == 55
 end
 


### PR DESCRIPTION
This resurfaces a code path for compiling standalone `.so`/`.dylib` shared libraries, analogous to `compile_executable`. 

Since the `_shlib` terminology we've been using has become a bit overloaded, denoting functions that generate alternately either  a `.o` object file or a`dlopen`-able `.dylib`/`.so` dynamic library / shared object file, I have disambiguated this where relevant to use the suffix `_obj` for functions intended to generate a `.o` object files , and the suffix `_dylib` for functions intended to generate `.dylib`/`.so` libraries.

There are a few minor clean-ups in `compile_executable` and some new tests as well.