### PR TITLE
Bump LLVM version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
 [compat]
 GPUCompiler = "0.13"
-LLVM = "4"
+LLVM = "4.8"
 julia = "1.7"
 
 [extras]


### PR DESCRIPTION
This should fix the breakages that happened on the MacOS master builds