### PR TITLE
Allow compilation to other target triples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ Hello, world!
 ```
 This latter approach comes with substantially more limitations, as you cannot rely on `libjulia` (see, e.g., [StaticTools.jl](https://github.com/brenhinkeller/StaticTools.jl) for some ways to work around these limitations).
 
+The low-level function `StaticCompiler.generate_obj` (not exported) generates object files. This can be used for more control of compilation. This can be used to cross-compile to other targets.
+
 ### Mixtape
 
 This feature allows one to change functionality when statically compiling. This uses code and API from [Mixtape](https://github.com/JuliaCompilerPlugins/Mixtape.jl) to transform lowered code much like [Cassette](https://github.com/JuliaLabs/Cassette.jl).

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -157,7 +157,6 @@ function generate_obj(f, tt, external = true, path::String = tempname(), name = 
                         kwargs...)
     mkpath(path)
     obj_path = joinpath(path, "$filenamebase.o")
-    tm = GPUCompiler.llvm_machine(external ? ExternalNativeCompilerTarget(target...) : NativeCompilerTarget(target...))
     #Get LLVM to generated a module of code for us. We don't want GPUCompiler's optimization passes.
     job = CompilerJob(NativeCompilerTarget(target...), 
                       FunctionSpec(f, tt, false, name), 
@@ -172,6 +171,7 @@ function generate_obj(f, tt, external = true, path::String = tempname(), name = 
 
     # Use Enzyme's annotation and optimization pipeline
     annotate!(mod)
+    tm = GPUCompiler.llvm_machine(external ? ExternalNativeCompilerTarget(target...) : NativeCompilerTarget(target...))
     optimize!(mod, tm)
 
     # Scoop up all the pointers in the optimized module, and replace them with unitialized global variables.

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -385,7 +385,7 @@ end
 
 @testset "Cross compiling" begin
 
-    x, obj_path = StaticCompiler.generate_obj(sin, Tuple{Float64}, true, tempname(); target = (triple = "wasm32-unknown-wasi", cpu = "wasm?", features = ""))
+    x, obj_path = StaticCompiler.generate_obj(x -> 2x, Tuple{Float64}, true, tempname(); target = (triple = "wasm32-unknown-wasi", cpu = "", features = ""))
 
 end
 

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -383,3 +383,9 @@ struct MyMix <: CompilationContext end
 
 end
 
+@testset "Cross compiling" begin
+
+    x, obj_path = StaticCompiler.generate_obj(sin, Tuple{Float64}, true, tempname(); target = (triple = "wasm32-unknown-wasi", cpu = "wasm?", features = ""))
+
+end
+


### PR DESCRIPTION
This would be handy for cross compilation and things like @Alexander-Barth's compilation to [WebAssembly](https://github.com/Alexander-Barth/FluidSimDemo-WebAssembly/) and @seelengrab's compilation to an [Arduino](https://seelengrab.github.io/articles/Running%20Julia%20baremetal%20on%20an%20Arduino/).

