### PR TITLE
actually test `foo_err`

### DIFF
--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -293,7 +293,7 @@ end
 
     # Compile a function that definitely fails
     @inline foo_err() = UInt64(-1)
-    filepath = compile_executable(maybe_throw, (Int, Ptr{Ptr{UInt8}}), tempdir())
+    filepath = compile_executable(foo_err, (Int, Ptr{Ptr{UInt8}}), tempdir())
     @test isfile(filepath)
     status = -1
     try

--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -293,7 +293,7 @@ end
 
     # Compile a function that definitely fails
     @inline foo_err() = UInt64(-1)
-    filepath = compile_executable(foo_err, (Int, Ptr{Ptr{UInt8}}), tempdir())
+    filepath = compile_executable(foo_err, (), tempdir())
     @test isfile(filepath)
     status = -1
     try

--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -293,7 +293,7 @@ end
 
     # Compile a function that definitely fails
     @inline foo_err() = UInt64(-1)
-    filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), tempdir())
+    filepath = compile_executable(maybe_throw, (Int, Ptr{Ptr{UInt8}}), tempdir())
     @test isfile(filepath)
     status = -1
     try


### PR DESCRIPTION
Fixing a typo from the test suite in https://github.com/tshort/StaticCompiler.jl/pull/98