### PR TITLE
Re-add nightly tests and integration tests

### DIFF
--- a/.github/workflows/ci-integration-nightly.yml
+++ b/.github/workflows/ci-integration-nightly.yml
@@ -1,0 +1,39 @@
+name: CI (Integration nightly)
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+jobs:
+  test-integration-nightly:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'nightly'
+          - '~1.9.0-0'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+        group:
+          - Integration
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        env:
+          GROUP: ${{ matrix.group }}

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -1,0 +1,38 @@
+name: CI (Integration)
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+jobs:
+  test-integration:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.8'
+        os:
+          - ubuntu-latest
+          - macOS-latest
+        arch:
+          - x64
+        group:
+          - Integration
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        env:
+          GROUP: ${{ matrix.group }}

--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -1,0 +1,37 @@
+name: CI (Julia nightly)
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - 'README.md'
+  pull_request:
+    branches:
+      - master
+    paths-ignore:
+      - 'README.md'
+jobs:
+  test-julia-nightly:
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - 'nightly'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+        group:
+          - Core
+    steps:
+      - uses: actions/checkout@v2
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        env:
+          GROUP: ${{ matrix.group }}


### PR DESCRIPTION
These were deleted in https://github.com/tshort/StaticCompiler.jl/pull/69 for some reason, I think it's good to test on nightly so we can at least be aware that breakage is coming. The integration tests are important because they're literally half the test suite.

I stumbled upon this because I ran the test suite on my local machine and found that the WASM tests were failing