### PR TITLE
Cleanup and more support for arrays of functions

### DIFF
--- a/.github/workflows/ci-integration-nightly.yml
+++ b/.github/workflows/ci-integration-nightly.yml
@@ -19,7 +19,6 @@ jobs:
       matrix:
         version:
           - 'nightly'
-          - '~1.9.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -18,6 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
+          - '1.9.0-rc3'
           - '1.8'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
 authors = ["Tom Short and contributors"]
-version = "0.4.10"
+version = "0.4.11"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -211,7 +211,7 @@ julia> using StaticCompiler
 
 julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocates.
            # Note, this `llvmcall` requires Julia 1.8+
-           Base.llvmcall((\"""
+           Base.llvmcall((\"\"\"
            ; External declaration of the puts function
            declare i32 @puts(i8* nocapture) nounwind
 
@@ -220,7 +220,7 @@ julia> function puts(s::Ptr{UInt8}) # Can't use Base.println because it allocate
                %call = call i32 (i8*) @puts(i8* %0)
                ret i32 0
            }
-           \""", "main"), Int32, Tuple{Ptr{UInt8}}, s)
+           \"\"\", "main"), Int32, Tuple{Ptr{UInt8}}, s)
        end
 puts (generic function with 1 method)
 

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -619,11 +619,11 @@ end
 #Return an LLVM module for multiple functions
 function native_llvm_module(funcs::Array; demangle = false, kwargs...)
     f,tt = funcs[1]
-    mod = native_llvm_module(f,tt, kwargs...)
+    mod = native_llvm_module(f,tt; kwargs...)
     if length(funcs) > 1
         for func in funcs[2:end]
             f,tt = func
-            tmod = native_llvm_module(f,tt, kwargs...)
+            tmod = native_llvm_module(f,tt; kwargs...)
             link!(mod,tmod)
         end
     end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -1,7 +1,7 @@
 ## interpreter
 
 using Core.Compiler:
-    AbstractInterpreter, InferenceResult, InferenceParams, InferenceState, MethodInstance, OptimizationParams, WorldView
+    AbstractInterpreter, InferenceResult, InferenceParams, InferenceState, MethodInstance, OptimizationParams, WorldView, get_world_counter
 using GPUCompiler:
     @safe_debug, AbstractCompilerParams, CodeCache, CompilerJob, methodinstance
 using CodeInfoTools
@@ -85,8 +85,13 @@ function custom_pass!(interp::StaticInterpreter, result::InferenceResult, mi::Co
     return src
 end
 
-function InferenceState(result::InferenceResult, cache::Symbol, interp::StaticInterpreter)
-    src = Core.Compiler.retrieve_code_info(result.linfo)
+function Core.Compiler.InferenceState(result::InferenceResult, cache::Symbol, interp::StaticInterpreter)
+    world = get_world_counter(interp)
+    src =  @static if VERSION >= v"1.10.0-DEV.873"
+        Core.Compiler.retrieve_code_info(result.linfo, world)
+    else
+         Core.Compiler.retrieve_code_info(result.linfo)
+    end
     mi = result.linfo
     src = custom_pass!(interp, result, mi, src)
     src === nothing && return nothing

--- a/src/pointer_patching.jl
+++ b/src/pointer_patching.jl
@@ -138,7 +138,7 @@ function get_pointers!(d, mod, inst)
                         LLVM.API.LLVMSetOperand(inst, i-1, gv)
                     else
                         gv_name = fix_name(String(gensym(repr(Core.Typeof(val)))))
-                        gv = LLVM.GlobalVariable(mod, llvmeltype(arg), gv_name, LLVM.addrspace(llvmtype(arg)))
+                        gv = LLVM.GlobalVariable(mod, llvmeltype(arg), gv_name, LLVM.addrspace(value_type(arg)))
 
                         LLVM.extinit!(gv, true)
                         LLVM.API.LLVMSetOperand(inst, i-1, gv)
@@ -153,7 +153,7 @@ function get_pointers!(d, mod, inst)
     end
 end
 
-llvmeltype(x::LLVM.Value) = eltype(LLVM.llvmtype(x))
+llvmeltype(x::LLVM.Value) = eltype(LLVM.value_type(x))
 
 function pointer_patching_diff(f, tt, path1=tempname(), path2=tempname(); show_reloc_table=false)
     tm = GPUCompiler.llvm_machine(NativeCompilerTarget())

--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -316,8 +316,6 @@ function squaresquaresquare(n)
 end
 
 @testset "Multiple Function Dylibs" begin
-
-
     funcs = [(squaresquare,(Float64,)), (squaresquaresquare,(Float64,))]
     filepath = compile_shlib(funcs, demangle=true)
 

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -159,7 +159,7 @@
         status = -1
         try
             isfile("loopvec_matrix") && rm("loopvec_matrix")
-            status = run(`$jlpath --startup=no --compile=min $testpath/scripts/loopvec_matrix.jl`)
+            status = run(`$jlpath --startup=no $testpath/scripts/loopvec_matrix.jl`)
         catch e
             @warn "Could not compile $testpath/scripts/loopvec_matrix.jl"
             println(e)
@@ -190,7 +190,7 @@
         status = -1
         try
             isfile("loopvec_matrix_stack") && rm("loopvec_matrix_stack")
-            status = run(`$jlpath --startup=no --compile=min $testpath/scripts/loopvec_matrix_stack.jl`)
+            status = run(`$jlpath --startup=no  $testpath/scripts/loopvec_matrix_stack.jl`)
         catch e
             @warn "Could not compile $testpath/scripts/loopvec_matrix_stack.jl"
             println(e)


### PR DESCRIPTION
This separates the `generate_obj` that `compile` uses from the `generate_obj` that all the standalone functions use, and rearranges stuff for a bit less code repetition.

Also, I mocked up support for the request in https://github.com/tshort/StaticCompiler.jl/issues/93, but I still am not really convinced that it makes any sense to have multiple functions going into `compile_executable`. 