### PR TITLE
Demangle by default

### DIFF
--- a/.github/workflows/ci-integration.yml
+++ b/.github/workflows/ci-integration.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9.0-rc3'
           - '1.8'
+          - '1.9'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         version:
           - '1.8'
-          - '^1.9.0-rc3'
+          - '1.9'
         os:
           - ubuntu-latest
           - macOS-latest
@@ -30,7 +30,7 @@ jobs:
         include:
           - arch: x86
             version: '1'
-            os: ubuntu-latest   
+            os: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
 authors = ["Tom Short and contributors"]
-version = "0.4.11"
+version = "0.4.12"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "StaticCompiler"
 uuid = "81625895-6c0f-48fc-b932-11a18313743c"
 authors = ["Tom Short and contributors"]
-version = "0.4.12"
+version = "0.5.0"
 
 [deps]
 Clang_jll = "0ee61d77-7f21-5576-8119-9fcc46b10100"
@@ -21,7 +21,7 @@ GPUCompiler = "0.19"
 LLVM = "5"
 MacroTools = "0.5"
 StaticTools = "0.8"
-julia = "1.8, 1.9"
+julia = "1.8"
 
 [extras]
 Formatting = "59287772-0a20-5a39-b81b-1366585eb4c0"

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -24,7 +24,8 @@ include("code_loading.jl")
 include("optimize.jl")
 include("quirks.jl")
 
-fix_name(s) = string("julia_", GPUCompiler.safe_name(s))
+fix_name(f::Function; kwargs...) = fix_name(repr(f); kwargs...)
+fix_name(s; demangle=true) = string(demangle ? "" : "julia_", GPUCompiler.safe_name(s))
 
 """
     compile(f, types, path::String = tempname()) --> (compiled_f, path)
@@ -91,9 +92,9 @@ with `load_function(path)`. `LazyStaticcompiledfunction`s contain the requisite 
 `StaticCompiledFunction` and may be called with arguments of type `types` as if it were a function with a
 single method (the method determined by `types`).
 """
-function compile(f, _tt, path::String = tempname(); 
-                 mixtape = NoContext(), 
-                 name = fix_name(repr(f)), 
+function compile(f, _tt, path::String = tempname();
+                 mixtape = NoContext(),
+                 name = fix_name(f),
                  filename = "obj",
                  strip_llvm = false,
                  strip_asm  = true,
@@ -117,7 +118,7 @@ end
 
 """
 ```julia
-generate_obj_for_compile(f, tt, path::String = tempname(), name = fix_name(repr(f)), filenamebase::String="obj";
+generate_obj_for_compile(f, tt, path::String = tempname(), name = fix_name(f), filenamebase::String="obj";
             \tmixtape = NoContext(),
             \tstrip_llvm = false,
             \tstrip_asm  = true,
@@ -129,11 +130,11 @@ Low level interface for compiling object code (`.o`) for for function `f` given
 a tuple type `tt` characterizing the types of the arguments for which the
 function will be compiled.
 
-`mixtape` defines a context that can be used to transform IR prior to compilation using 
+`mixtape` defines a context that can be used to transform IR prior to compilation using
 [Mixtape](https://github.com/JuliaCompilerPlugins/Mixtape.jl) features.
 
 `target` can be used to change the output target. This is useful for compiling to WebAssembly and embedded targets.
-This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings). 
+This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings).
 The defaults compile to the native target.
 
 ### Examples
@@ -151,7 +152,7 @@ shell> tree \$path
 0 directories, 1 file
 ```
 """
-function generate_obj_for_compile(f, tt, external = true, path::String = tempname(), name = fix_name(repr(f)), filenamebase::String="obj";
+function generate_obj_for_compile(f, tt, external = true, path::String = tempname(), name = fix_name(f), filenamebase::String="obj";
                         mixtape = NoContext(),
                         strip_llvm = false,
                         strip_asm  = true,
@@ -168,7 +169,7 @@ function generate_obj_for_compile(f, tt, external = true, path::String = tempnam
 
     mod, meta = GPUCompiler.JuliaContext() do context
         GPUCompiler.codegen(:llvm, job; strip=strip_llvm, only_entry=false, validate=false, optimize=false, ctx=context)
-    end  
+    end
 
     # Use Enzyme's annotation and optimization pipeline
     annotate!(mod)
@@ -263,17 +264,19 @@ shell> ./hello
 Hello, world!
 ```
 """
-function compile_executable(f::Function, types=(), path::String="./", name=fix_name(repr(f));
+function compile_executable(f::Function, types=(), path::String="./", name=f;
                             also_expose=[],
-                            filename=name,
+                            filename=fix_name(name),
+                            demangle=false,
                             cflags=``,
                             kwargs...)
-    compile_executable(vcat([(f, types)], also_expose), path, name; filename, cflags, kwargs...)
+    compile_executable(vcat([(f, types)], also_expose), path, fix_name(name; demangle); filename, cflags, kwargs...)
 end
 
 
-function compile_executable(funcs::Array, path::String="./", name=fix_name(repr(funcs[1][1]));
-        filename=name,
+function compile_executable(funcs::Array, path::String="./", name=first(first(funcs));
+        filename=fix_name(name),
+        demangle=false,
         cflags=``,
         kwargs...
     )
@@ -287,8 +290,8 @@ function compile_executable(funcs::Array, path::String="./", name=fix_name(repr(
     isconcretetype(rt) || error("`$f$types` did not infer to a concrete type. Got `$rt`")
     nativetype = isprimitivetype(rt) || isa(rt, Ptr)
     nativetype || @warn "Return type `$rt` of `$f$types` does not appear to be a native type. Consider returning only a single value of a native machine type (i.e., a single float, int/uint, bool, or pointer). \n\nIgnoring this warning may result in Undefined Behavior!"
-    
-    generate_executable(funcs, path, name, filename; cflags=cflags, kwargs...)
+
+    generate_executable(funcs, path, fix_name(name; demangle), filename; cflags, kwargs...)
     joinpath(abspath(path), filename)
 end
 
@@ -327,8 +330,9 @@ julia> ccall(("julia_test", "test.dylib"), Float64, (Int64,), 100_000)
 5.2564961094956075
 ```
 """
-function compile_shlib(f::Function, types=(), path::String="./", name=fix_name(repr(f));
-        filename=name,
+function compile_shlib(f::Function, types=(), path::String="./", name=f;
+        filename=fix_name(name),
+        demangle=false,
         cflags=``,
         kwargs...
     )
@@ -341,7 +345,7 @@ function compile_shlib(f::Function, types=(), path::String="./", name=fix_name(r
     nativetype = isprimitivetype(rt) || isa(rt, Ptr)
     nativetype || @warn "Return type `$rt` of `$f$types` does not appear to be a native type. Consider returning only a single value of a native machine type (i.e., a single float, int/uint, bool, or pointer). \n\nIgnoring this warning may result in Undefined Behavior!"
 
-    generate_shlib(f, tt, true, path, name, filename; cflags=cflags, kwargs...)
+    generate_shlib(f, tt, true, path, fix_name(name; demangle), filename; cflags, kwargs...)
 
     joinpath(abspath(path), filename * "." * Libdl.dlext)
 end
@@ -363,7 +367,7 @@ function compile_shlib(funcs::Array, path::String="./";
         nativetype || @warn "Return type `$rt` of `$f$types` does not appear to be a native type. Consider returning only a single value of a native machine type (i.e., a single float, int/uint, bool, or pointer). \n\nIgnoring this warning may result in Undefined Behavior!"
     end
 
-    generate_shlib(funcs, true, path, filename; demangle=demangle, cflags=cflags, kwargs...)
+    generate_shlib(funcs, true, path, filename; demangle, cflags, kwargs...)
 
     joinpath(abspath(path), filename * "." * Libdl.dlext)
 end
@@ -381,9 +385,9 @@ The keword argument `demangle=true` will remove this prefix, but is currently on
 supported the second (multi-function-shlib) method.
 ```
 """
-function compile_wasm(f::Function, types=(); 
+function compile_wasm(f::Function, types=();
         path::String="./",
-        filename=fix_name(repr(f)),
+        filename=fix_name(f, demangle=false),
         flags=``,
         kwargs...
     )
@@ -392,7 +396,7 @@ function compile_wasm(f::Function, types=();
     run(`$(lld()) -flavor wasm --no-entry --export-all $flags $obj_path/obj.o -o $path/$name.wasm`)
     joinpath(abspath(path), filename * ".wasm")
 end
-function compile_wasm(funcs::Array; 
+function compile_wasm(funcs::Array;
         path::String="./",
         filename="libfoo",
         flags=``,
@@ -447,7 +451,7 @@ function generate_shlib_fptr(path::String, name, filename::String=name)
     fptr
 end
 # As above, but also compile (maybe remove this method in the future?)
-function generate_shlib_fptr(f, tt, path::String=tempname(), name = fix_name(repr(f)), filename::String=name;
+function generate_shlib_fptr(f, tt, path::String=tempname(), name = fix_name(f), filename::String=name;
                             temp::Bool=true,
                             kwargs...)
 
@@ -486,7 +490,7 @@ function generate_executable(f, tt, args...; kwargs...)
     generate_executable([(f, tt)], args...; kwargs...)
 end
 
-function generate_executable(funcs::Array, path=tempname(), name=fix_name(repr(funcs[1][1])), filename=string(name);
+function generate_executable(funcs::Array, path=tempname(), name=fix_name(first(first(funcs))), filename=string(name);
                              demangle=false,
                              cflags=``,
                              kwargs...
@@ -494,7 +498,7 @@ function generate_executable(funcs::Array, path=tempname(), name=fix_name(repr(f
     lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
     exec_path = joinpath(path, filename)
     external = true
-    _, obj_path = generate_obj(funcs, external, path, filename; demangle=demangle, kwargs...)
+    _, obj_path = generate_obj(funcs, external, path, filename; demangle, kwargs...)
     # Pick a compiler
     cc = Sys.isapple() ? `cc` : clang()
     # Compile!
@@ -561,13 +565,13 @@ julia> ccall(("julia_test", "example/test.dylib"), Float64, (Int64,), 100_000)
 5.2564961094956075
 ```
 """
-function generate_shlib(f::Function, tt, external::Bool=true, path::String=tempname(), name=fix_name(repr(f)), filename=name;
+function generate_shlib(f::Function, tt, external::Bool=true, path::String=tempname(), name=fix_name(f), filename=name;
         cflags=``, demangle=false,
         kwargs...
     )
     lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
-    _, obj_path = generate_obj([(f, tt)], external, path, filename; demangle=demangle, kwargs...)
-    
+    _, obj_path = generate_obj([(f, tt)], external, path, filename; demangle, kwargs...)
+
     # Pick a Clang
     cc = Sys.isapple() ? `cc` : clang()
     # Compile
@@ -584,7 +588,7 @@ function generate_shlib(funcs::Array, external::Bool=true, path::String=tempname
 
     lib_path = joinpath(path, "$filename.$(Libdl.dlext)")
 
-    _, obj_path = generate_obj(funcs, external, path, filename; demangle=demangle, kwargs...)
+    _, obj_path = generate_obj(funcs, external, path, filename; demangle, kwargs...)
     # Pick a Clang
     cc = Sys.isapple() ? `cc` : clang()
     # Compile!
@@ -604,7 +608,7 @@ function native_code_typed(@nospecialize(func), @nospecialize(types); kwargs...)
 end
 
 # Return an LLVM module
-function native_llvm_module(f, tt, name = fix_name(repr(f)); kwargs...)
+function native_llvm_module(f, tt, name = fix_name(f); kwargs...)
     job, kwargs = native_job(f, tt, true; name, kwargs...)
     m, _ = GPUCompiler.JuliaContext() do context
         GPUCompiler.codegen(:llvm, job; strip=true, only_entry=false, validate=false, ctx=context)
@@ -612,28 +616,20 @@ function native_llvm_module(f, tt, name = fix_name(repr(f)); kwargs...)
     return m
 end
 
-function native_code_native(@nospecialize(f), @nospecialize(tt), name = fix_name(repr(f)); kwargs...)
+function native_code_native(@nospecialize(f), @nospecialize(tt), name=fix_name(f); kwargs...)
     job, kwargs = native_job(f, tt, true; name, kwargs...)
     GPUCompiler.code_native(stdout, job; kwargs...)
 end
 
 #Return an LLVM module for multiple functions
-function native_llvm_module(funcs::Array; demangle = false, kwargs...)
+function native_llvm_module(funcs::Array; demangle=false, kwargs...)
     f,tt = funcs[1]
-    mod = native_llvm_module(f,tt; kwargs...)
+    mod = native_llvm_module(f,tt,fix_name(f; demangle); kwargs...)
     if length(funcs) > 1
         for func in funcs[2:end]
             f,tt = func
-            tmod = native_llvm_module(f,tt; kwargs...)
+            tmod = native_llvm_module(f,tt,fix_name(f; demangle); kwargs...)
             link!(mod,tmod)
-        end
-    end
-    if demangle
-        for func in functions(mod)
-            fname = name(func)
-            if fname[1:6] == "julia_"
-                name!(func,fname[7:end])
-            end
         end
     end
     LLVM.ModulePassManager() do pass_manager #remove duplicate functions
@@ -659,11 +655,11 @@ Low level interface for compiling object code (`.o`) for for function `f` given
 a tuple type `tt` characterizing the types of the arguments for which the
 function will be compiled.
 
-`mixtape` defines a context that can be used to transform IR prior to compilation using 
+`mixtape` defines a context that can be used to transform IR prior to compilation using
 [Mixtape](https://github.com/JuliaCompilerPlugins/Mixtape.jl) features.
 
 `target` can be used to change the output target. This is useful for compiling to WebAssembly and embedded targets.
-This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings). 
+This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings).
 The defaults compile to the native target.
 
 ### Examples
@@ -701,24 +697,24 @@ Low level interface for compiling object code (`.o`) for an array of Tuples
 (f, tt) where each function `f` and tuple type `tt` determine the set of methods
 which will be compiled.
 
-`mixtape` defines a context that can be used to transform IR prior to compilation using 
+`mixtape` defines a context that can be used to transform IR prior to compilation using
 [Mixtape](https://github.com/JuliaCompilerPlugins/Mixtape.jl) features.
 
 `target` can be used to change the output target. This is useful for compiling to WebAssembly and embedded targets.
-This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings). 
+This is a named tuple with fields `triple`, `cpu`, and `features` (each of these are strings).
 The defaults compile to the native target.
 """
 function generate_obj(funcs::Array, external::Bool, path::String = tempname(), filenamebase::String="obj";
-                        demangle =false,
+                        demangle = false,
                         strip_llvm = false,
-                        strip_asm  = true,
-                        opt_level=3,
+                        strip_asm = true,
+                        opt_level = 3,
                         kwargs...)
     f, tt = funcs[1]
     mkpath(path)
     obj_path = joinpath(path, "$filenamebase.o")
     fakejob, kwargs = native_job(f, tt, external; kwargs...)
-    mod = native_llvm_module(funcs; demangle = demangle, kwargs...)
+    mod = native_llvm_module(funcs; demangle, kwargs...)
     obj, _ = GPUCompiler.emit_asm(fakejob, mod; strip=strip_asm, validate=false, format=LLVM.API.LLVMObjectFile)
     open(obj_path, "w") do io
         write(io, obj)

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -487,15 +487,16 @@ function generate_executable(funcs::Union{Array,Tuple}, path=tempname(), name=fi
         entry = demangle ? "_$name" : "_julia_$name"
         run(`$cc -e $entry $cflags $obj_path -o $exec_path`)
     else
+        fn = demangle ? "$name" : "julia_$name"
         # Write a minimal wrapper to avoid having to specify a custom entry
         wrapper_path = joinpath(path, "wrapper.c")
         f = open(wrapper_path, "w")
-        print(f, """int $name(int argc, char** argv);
+        print(f, """int $fn(int argc, char** argv);
         void* __stack_chk_guard = (void*) $(rand(UInt) >> 1);
 
         int main(int argc, char** argv)
         {
-            $name(argc, argv);
+            $fn(argc, argv);
             return 0;
         }""")
         close(f)

--- a/src/target.jl
+++ b/src/target.jl
@@ -82,10 +82,10 @@ for target in (:NativeCompilerTarget, :ExternalNativeCompilerTarget)
         GPUCompiler.can_throw(job::GPUCompiler.CompilerJob{$target}) = true
 
         GPUCompiler.get_interpreter(job::GPUCompiler.CompilerJob{$target, StaticCompilerParams}) =
-            StaticInterpreter(job.config.params.cache, GPUCompiler.method_table(job), job.world, 
-                              GPUCompiler.inference_params(job), GPUCompiler.optimization_params(job), 
-                              job.config.params.mixtape)    
-        GPUCompiler.ci_cache(job::GPUCompiler.CompilerJob{$target, StaticCompilerParams}) = job.config.params.cache       
+            StaticInterpreter(job.config.params.cache, GPUCompiler.method_table(job), job.world,
+                              GPUCompiler.inference_params(job), GPUCompiler.optimization_params(job),
+                              job.config.params.mixtape)
+        GPUCompiler.ci_cache(job::GPUCompiler.CompilerJob{$target, StaticCompilerParams}) = job.config.params.cache
     end
 end
 
@@ -94,12 +94,12 @@ GPUCompiler.method_table(@nospecialize(job::GPUCompiler.CompilerJob{ExternalNati
 
 function native_job(@nospecialize(func::Function), @nospecialize(types::Type), external::Bool;
         mixtape = NoContext(),
-        name = fix_name(repr(func)),
+        name = fix_name(func),
         kernel::Bool = false,
         target = (),
         kwargs...
     )
-    source = methodinstance(typeof(func), Base.to_tuple_type(types)) 
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = external ? ExternalNativeCompilerTarget(;target...) : NativeCompilerTarget(;target...)
     params = StaticCompilerParams(mixtape = mixtape)
     config = GPUCompiler.CompilerConfig(target, params, name = name, kernel = kernel)
@@ -107,7 +107,7 @@ function native_job(@nospecialize(func::Function), @nospecialize(types::Type), e
 end
 
 function native_job(@nospecialize(func), @nospecialize(types), external; mixtape = NoContext(), kernel::Bool=false, name=fix_name(repr(func)), target = (), kwargs...)
-    source = methodinstance(typeof(func), Base.to_tuple_type(types)) 
+    source = methodinstance(typeof(func), Base.to_tuple_type(types))
     target = external ? ExternalNativeCompilerTarget(;target...) : NativeCompilerTarget(;target...)
     params = StaticCompilerParams(mixtape = mixtape)
     config = GPUCompiler.CompilerConfig(target, params, name = name, kernel = kernel)

--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -1,3 +1,6 @@
+workdir = tempdir()
+# workdir = "./" # For debugging
+
 remote_load_call(path, args...) = fetch(@spawnat 2 load_function(path)(args...))
 
 @testset "Basics" begin
@@ -225,9 +228,6 @@ end
     C .= fetch(@spawnat 2 (load_function(path)(C, A, B); C))
     @test C ≈ A*B
 end
-
-workdir = tempdir()
-# workdir = "./" # For debugging
 
 @testset "Standalone Dylibs" begin
     # Test function

--- a/test/testcore.jl
+++ b/test/testcore.jl
@@ -226,21 +226,32 @@ end
     @test C ≈ A*B
 end
 
+workdir = tempdir()
+# workdir = "./" # For debugging
+
 @testset "Standalone Dylibs" begin
     # Test function
     # (already defined)
     # fib(n) = n <= 1 ? n : fib(n - 1) + fib(n - 2)
 
     #Compile dylib
-    name = "julia_" * repr(fib)
-    filepath = compile_shlib(fib, (Int,), "./", name)
+    name = repr(fib)
+    filepath = compile_shlib(fib, (Int,), workdir, name, demangle=true)
     @test occursin("fib.$(Libdl.dlext)", filepath)
-
-    # Open dylib
+    # Open dylib manually
     ptr = Libdl.dlopen(filepath, Libdl.RTLD_LOCAL)
     fptr = Libdl.dlsym(ptr, name)
     @test fptr != C_NULL
     @test ccall(fptr, Int, (Int,), 10) == 55
+    Libdl.dlclose(ptr)
+
+    # As above, but without demangling
+    filepath = compile_shlib(fib, (Int,), workdir, name, demangle=false)
+    ptr = Libdl.dlopen(filepath, Libdl.RTLD_LOCAL)
+    fptr = Libdl.dlsym(ptr, "julia_"*name)
+    @test fptr != C_NULL
+    @test ccall(fptr, Int, (Int,), 10) == 55
+    Libdl.dlclose(ptr)
 end
 
 @testset "Standalone Executables" begin
@@ -254,8 +265,12 @@ end
         return 0
     end
 
-    filepath = compile_executable(foo, (), tempdir())
+    filepath = compile_executable(foo, (), workdir, demangle=false)
+    r = run(`$filepath`);
+    @test isa(r, Base.Process)
+    @test r.exitcode == 0
 
+    filepath = compile_executable(foo, (), workdir, demangle=true)
     r = run(`$filepath`);
     @test isa(r, Base.Process)
     @test r.exitcode == 0
@@ -285,15 +300,20 @@ end
         return 0
     end
 
-    filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), tempdir())
-
+    filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), workdir, demangle=false)
     r = run(`$filepath Hello, world!`);
     @test isa(r, Base.Process)
     @test r.exitcode == 0
 
+    filepath = compile_executable(print_args, (Int, Ptr{Ptr{UInt8}}), workdir, demangle=true)
+    r = run(`$filepath Hello, world!`);
+    @test isa(r, Base.Process)
+    @test r.exitcode == 0
+
+
     # Compile a function that definitely fails
     @inline foo_err() = UInt64(-1)
-    filepath = compile_executable(foo_err, (), tempdir())
+    filepath = compile_executable(foo_err, (), workdir, demangle=true)
     @test isfile(filepath)
     status = -1
     try
@@ -317,9 +337,8 @@ end
 
 @testset "Multiple Function Dylibs" begin
 
-
     funcs = [(squaresquare,(Float64,)), (squaresquaresquare,(Float64,))]
-    filepath = compile_shlib(funcs, demangle=true)
+    filepath = compile_shlib(funcs, workdir, demangle=true)
 
     ptr = Libdl.dlopen(filepath, Libdl.RTLD_LOCAL)
 

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -4,7 +4,7 @@
     testpath = pwd()
     scratch = tempdir()
     cd(scratch)
-    jlpath = joinpath(Sys.BINDIR, Base.julia_exename()) # Get path to julia executable
+    jlpath = joinpath(Sys.BINDIR, Base.exename()) # Get path to julia executable
 
     ## --- Times table, file IO, mallocarray
     let
@@ -14,7 +14,7 @@
         # faster.
         status = -1
         try
-            isfile("julia_times_table") && rm("julia_times_table")
+            isfile("times_table") && rm("times_table")
             status = run(`$jlpath --startup=no --compile=min $testpath/scripts/times_table.jl`)
         catch e
             @warn "Could not compile $testpath/scripts/times_table.jl"
@@ -27,7 +27,7 @@
         println("5x5 times table:")
         status = -1
         try
-            status = run(`./julia_times_table 5 5`)
+            status = run(`./times_table 5 5`)
         catch e
             @warn "Could not run $(scratch)/times_table"
             println(e)
@@ -58,7 +58,7 @@
         println("3x3 malloc arrays via do-block syntax:")
         status = -1
         try
-            status = run(`./julia_withmallocarray 3 3`)
+            status = run(`./withmallocarray 3 3`)
         catch e
             @warn "Could not run $(scratch)/withmallocarray"
             println(e)
@@ -85,7 +85,7 @@
         println("5x5 uniform random matrix:")
         status = -1
         try
-            status = run(`./julia_rand_matrix 5 5`)
+            status = run(`./rand_matrix 5 5`)
         catch e
             @warn "Could not run $(scratch)/rand_matrix"
             println(e)
@@ -113,7 +113,7 @@
         println("5x5 Normal random matrix:")
         status = -1
         try
-            status = run(`./julia_randn_matrix 5 5`)
+            status = run(`./randn_matrix 5 5`)
         catch e
             @warn "Could not run $(scratch)/randn_matrix"
             println(e)
@@ -143,7 +143,7 @@
             println("10x10 table sum:")
             status = -1
             try
-                status = run(`./julia_loopvec_product 10 10`)
+                status = run(`./loopvec_product 10 10`)
             catch e
                 @warn "Could not run $(scratch)/loopvec_product"
                 println(e)
@@ -171,7 +171,7 @@
         println("10x5 matrix product:")
         status = -1
         try
-            status = run(`./julia_loopvec_matrix 10 5`)
+            status = run(`./loopvec_matrix 10 5`)
         catch e
             @warn "Could not run $(scratch)/loopvec_matrix"
             println(e)
@@ -202,7 +202,7 @@
         println("10x5 matrix product:")
         status = -1
         try
-            status = run(`./julia_loopvec_matrix_stack`)
+            status = run(`./loopvec_matrix_stack`)
         catch e
             @warn "Could not run $(scratch)/loopvec_matrix_stack"
             println(e)
@@ -233,7 +233,7 @@
         println("String indexing and handling:")
         status = -1
         try
-            status = run(`./julia_print_args foo bar`)
+            status = run(`./print_args foo bar`)
         catch e
             @warn "Could not run $(scratch)/print_args"
             println(e)
@@ -261,7 +261,7 @@
         println("Error handling:")
         status = -1
         try
-            status = run(`./julia_maybe_throw 10`)
+            status = run(`./maybe_throw 10`)
         catch e
             @warn "Could not run $(scratch)/maybe_throw"
             println(e)
@@ -297,7 +297,7 @@
         println("Interop:")
         status = -1
         try
-            status = run(`./julia_interop`)
+            status = run(`./interop`)
         catch e
             @warn "Could not run $(scratch)/interop"
             println(e)
@@ -394,4 +394,3 @@ end
     wasm_path2 = compile_wasm([(m2, (Float64,)), (m3, (Float64,))])
 
 end
-

--- a/test/testintegration.jl
+++ b/test/testintegration.jl
@@ -1,10 +1,11 @@
+# Setup
+testpath = pwd()
+scratch = tempdir()
+cd(scratch)
 
 @testset "Standalone Executable Integration" begin
-    # Setup
-    testpath = pwd()
-    scratch = tempdir()
-    cd(scratch)
-    jlpath = joinpath(Sys.BINDIR, Base.exename()) # Get path to julia executable
+
+    jlpath = joinpath(Sys.BINDIR, Base.julia_exename()) # Get path to julia executable
 
     ## --- Times table, file IO, mallocarray
     let
@@ -35,7 +36,7 @@
         @test isa(status, Base.Process)
         @test isa(status, Base.Process) && status.exitcode == 0
         # Test ascii output
-        @test parsedlm(Int, c"table.tsv", '\t') == (1:5)*(1:5)'
+        @test parsedlm(Int, c"table.tsv", '\t') == (1:5)*(1:5)' broken=Sys.ARCH===:aarch64
         # Test binary output
         @test fread!(szeros(Int, 5,5), c"table.b") == (1:5)*(1:5)'
     end
@@ -180,7 +181,7 @@
         @test isa(status, Base.Process) && status.exitcode == 0
         A = (1:10) * (1:5)'
         # Check ascii output
-        @test parsedlm(c"table.tsv",'\t') == A' * A
+        @test parsedlm(c"table.tsv",'\t') == A' * A broken=Sys.ARCH===:aarch64
         # Check binary output
         @test fread!(szeros(5,5), c"table.b") == A' * A
     end
@@ -210,7 +211,7 @@
         @test isa(status, Base.Process)
         @test isa(status, Base.Process) && status.exitcode == 0
         A = (1:10) * (1:5)'
-        @test parsedlm(c"table.tsv",'\t') == A' * A
+        @test parsedlm(c"table.tsv",'\t') == A' * A broken=Sys.ARCH===:aarch64
     end
 
 
@@ -307,9 +308,6 @@
     end
     end
 
-    ## --- Clean up
-
-    cd(testpath)
 end
 
 # Mixtape
@@ -384,6 +382,9 @@ struct MyMix <: CompilationContext end
 end
 
 @testset "Cross compiling to WebAssembly" begin
+    testpath = pwd()
+    scratch = tempdir()
+    cd(scratch)
 
     m2(x) = 2x
     m3(x) = 3x
@@ -394,3 +395,7 @@ end
     wasm_path2 = compile_wasm([(m2, (Float64,)), (m3, (Float64,))])
 
 end
+
+## --- Clean up
+
+cd(testpath)


### PR DESCRIPTION
So believe it or not this actually doesn't break anything in StaticTools AFAICT, but it'll be breaking for anyone who's using StaticCompiler to compile shlibs that they then call from another language (since then all the function names won't have the extra `julia_` added in front)