### PR TITLE
Convert repr to string(nameof( ))

### DIFF
--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -25,7 +25,7 @@ include("code_loading.jl")
 include("optimize.jl")
 include("quirks.jl")
 
-fix_name(f::Function) = fix_name(repr(f))
+fix_name(f::Function) = fix_name(string(nameof(f)))
 fix_name(s) = String(GPUCompiler.safe_name(s))
 
 """
@@ -199,7 +199,7 @@ end
 
 """
 ```julia
-compile_executable(f::Function, types::Tuple, path::String, [name::String=repr(f)];
+compile_executable(f::Function, types::Tuple, path::String, [name::String=string(nameof(f))];
     filename::String=name,
     cflags=``, # Specify libraries you would like to link against, and other compiler options here
     also_expose=[],
@@ -294,7 +294,7 @@ end
 
 """
 ```julia
-compile_shlib(f::Function, types::Tuple, [path::String="./"], [name::String=repr(f)]; filename::String=name, cflags=``, kwargs...)
+compile_shlib(f::Function, types::Tuple, [path::String="./"], [name::String=string(nameof(f))]; filename::String=name, cflags=``, kwargs...)
 compile_shlib(funcs::Array, [path::String="./"]; filename="libfoo", demangle=true, cflags=``, kwargs...)
 ```
 As `compile_executable`, but compiling to a standalone `.dylib`/`.so` shared library.
@@ -355,7 +355,7 @@ end
 
 """
 ```julia
-compile_wasm(f::Function, types::Tuple, [path::String="./"], [name::String=repr(f)]; filename::String=name, flags=``, kwargs...)
+compile_wasm(f::Function, types::Tuple, [path::String="./"], [name::String=string(nameof(f))]; filename::String=name, flags=``, kwargs...)
 compile_wasm(funcs::Union{Array,Tuple}, [path::String="./"]; filename="libfoo", demangle=true, flags=``, kwargs...)
 ```
 As `compile_shlib`, but compiling to a WebAssembly library.

--- a/src/pointer_patching.jl
+++ b/src/pointer_patching.jl
@@ -157,7 +157,7 @@ llvmeltype(x::LLVM.Value) = eltype(LLVM.value_type(x))
 
 function pointer_patching_diff(f, tt, path1=tempname(), path2=tempname(); show_reloc_table=false)
     tm = GPUCompiler.llvm_machine(NativeCompilerTarget())
-    job, kwargs = native_job(f, tt, false; name=fix_name(repr(f)))
+    job, kwargs = native_job(f, tt, false; name=fix_name(string(nameof(f))))
     #Get LLVM to generated a module of code for us. We don't want GPUCompiler's optimization passes.
     mod, meta = GPUCompiler.JuliaContext() do context
         GPUCompiler.codegen(:llvm, job; strip=true, only_entry=false, validate=false, optimize=false, ctx=context)


### PR DESCRIPTION
Some uses of `repr` end up creating long names with the modules prepended. If they are created in a temporary module, it's even worse. So, this PR substitutes `nameof` instead to give just the name of the function.