### PR TITLE
Contextfix

### DIFF
--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -595,7 +595,6 @@ end
 #Return an LLVM module for multiple functions
 function native_llvm_module(funcs::Union{Array,Tuple}; demangle=true, kwargs...)
     f,tt = funcs[1]
-    #mod = native_llvm_module(f,tt; demangle, kwargs...)
     tsctx = GPUCompiler.ThreadSafeContext()
     ctx = GPUCompiler.context(tsctx)
     GPUCompiler.activate(ctx)
@@ -608,7 +607,6 @@ function native_llvm_module(funcs::Union{Array,Tuple}; demangle=true, kwargs...)
     if length(funcs) > 1
         for func in funcs[2:end]
             f,tt = func
-            #tmod = native_llvm_module(f,tt; demangle, kwargs...)
             name_f = fix_name(f)
             if !demangle
                 name_f = "julia_"*name_f

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -598,22 +598,22 @@ function native_llvm_module(funcs::Union{Array,Tuple}; demangle=true, kwargs...)
     #mod = native_llvm_module(f,tt; demangle, kwargs...)
     tsctx = GPUCompiler.ThreadSafeContext()
     ctx = GPUCompiler.context(tsctx)
-    name1 = fix_name(f)
     GPUCompiler.activate(ctx)
+    name_f = fix_name(f)
     if !demangle
-        name1 = "julia_"*name1
+        name_f = "julia_"*name_f
     end
-    job, kwargs = native_job(f, tt, true; name1, kwargs...)
+    job, kwargs = native_job(f, tt, true; name = name_f, kwargs...)
     mod,_ = GPUCompiler.codegen(:llvm, job; strip=true, only_entry=false, validate=false)
     if length(funcs) > 1
         for func in funcs[2:end]
             f,tt = func
             #tmod = native_llvm_module(f,tt; demangle, kwargs...)
-            name = fix_name(f)
+            name_f = fix_name(f)
             if !demangle
-                name = "julia_"*name
+                name_f = "julia_"*name_f
             end
-            job, kwargs = native_job(f, tt, true; name, kwargs...)
+            job, kwargs = native_job(f, tt, true; name = name_f, kwargs...)
             tmod,_ = GPUCompiler.codegen(:llvm, job; strip=true, only_entry=false, validate=false)
             link!(mod,tmod)
         end

--- a/src/StaticCompiler.jl
+++ b/src/StaticCompiler.jl
@@ -595,7 +595,7 @@ end
 #Return an LLVM module for multiple functions
 function native_llvm_module(funcs::Union{Array,Tuple}; demangle=true, kwargs...)
     f,tt = funcs[1]
-    mod = native_llvm_module(f,tt; demangle, kwargs...)
+    #mod = native_llvm_module(f,tt; demangle, kwargs...)
     tsctx = GPUCompiler.ThreadSafeContext()
     ctx = GPUCompiler.context(tsctx)
     name1 = fix_name(f)
@@ -608,17 +608,18 @@ function native_llvm_module(funcs::Union{Array,Tuple}; demangle=true, kwargs...)
     if length(funcs) > 1
         for func in funcs[2:end]
             f,tt = func
+            #tmod = native_llvm_module(f,tt; demangle, kwargs...)
             name = fix_name(f)
             if !demangle
                 name = "julia_"*name
             end
             job, kwargs = native_job(f, tt, true; name, kwargs...)
-            #tmod = native_llvm_module(f,tt; demangle, kwargs...)
             tmod,_ = GPUCompiler.codegen(:llvm, job; strip=true, only_entry=false, validate=false)
             link!(mod,tmod)
         end
     end
     GPUCompiler.deactivate(ctx)
+    GPUCompiler.dispose(tsctx)
     # Just to be sure
     for (modfunc, func) in zip(functions(mod), funcs)
         fname = name(modfunc)


### PR DESCRIPTION
addressing https://github.com/tshort/StaticCompiler.jl/issues/138 
native_llvm_module for multiple functions now starts a context compiles and links the functions within the same context .